### PR TITLE
Fix incorrect workgroup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,24 @@ This repository contains information about the various workgroups contributing t
 
 | Workgroup | Description | Status |
 |-----------|-------------|---------|
-| [AI Trader (PMAIRCA)](workgroups/ai-trader/README.md) | Focuses on Promotion, Marketing, AI, Research, Community, and Adoption initiatives. Works on AI technologies, product development, and community engagement. | Active |
-| [ElizaCon](workgroups/elizacon/README.md) | Plans and organizes the ElizaCon event, an AI and blockchain-focused conference bringing together Eliza and Solana communities. | Active |
-| [Hackathons](workgroups/hackathons/README.md) | Organizes hackathons and events, develops tools for event management, and promotes initiatives through targeted events. | Active |
-| [Merch](workgroups/merch/README.md) | Explores and develops merchandise ideas for the elizaOS community, with a current focus on custom clothing options. | Active |
-| [Organization](workgroups/org/README.md) | Handles organizational matters including onboarding processes, leadership code of conduct, and TEE integration discussions. | Active |
-| [Partners NFT](workgroups/partners-nft/README.md) | Manages NFT-related initiatives, including auctions, artist collaboration, and integration with Discord and other platforms. | Active |
-| [Platform](workgroups/platform/README.md) | Develops and maintains the hosting infrastructure and launchpad for the Eliza AI ecosystem. | Active |
-| [Swarms](workgroups/swarms/README.md) | Explores swarm intelligence, multi-agent systems, and human-AI collaboration, including brain upload projects and human-agent pairs. | Active |
-| [Tokenomics](workgroups/tokenomics/README.md) | Develops the ecosystem's economic model, focusing on dual-token systems, staking mechanisms, and sustainable value creation. | Active |
-| [Trust](workgroups/trust/README.md) | Researches and implements reputation systems, trust mechanisms, and governance models for decentralized environments. | Active |
-| [Whitepaper](workgroups/whitepaper/README.md) | Collaborates on technical whitepapers and reports related to AI technologies and the Eliza project. | Active |
+| [AI Trader (PMAIRCA)](ai-trader/README.md) | Focuses on Promotion, Marketing, AI, Research, Community, and Adoption initiatives. Works on AI technologies, product development, and community engagement. | Active |
+| [ElizaCon](elizacon/README.md) | Plans and organizes the ElizaCon event, an AI and blockchain-focused conference bringing together Eliza and Solana communities. | Active |
+| [Hackathons](hackathons/README.md) | Organizes hackathons and events, develops tools for event management, and promotes initiatives through targeted events. | Active |
+| [Merch](merch/README.md) | Explores and develops merchandise ideas for the elizaOS community, with a current focus on custom clothing options. | Active |
+| [Organization](org/README.md) | Handles organizational matters including onboarding processes, leadership code of conduct, and TEE integration discussions. | Active |
+| [Partners NFT](partners-nft/README.md) | Manages NFT-related initiatives, including auctions, artist collaboration, and integration with Discord and other platforms. | Active |
+| [Platform](platform/README.md) | Develops and maintains the hosting infrastructure and launchpad for the Eliza AI ecosystem. | Active |
+| [Swarms](swarms/README.md) | Explores swarm intelligence, multi-agent systems, and human-AI collaboration, including brain upload projects and human-agent pairs. | Active |
+| [Tokenomics](tokenomics/README.md) | Develops the ecosystem's economic model, focusing on dual-token systems, staking mechanisms, and sustainable value creation. | Active |
+| [Trust](trust/README.md) | Researches and implements reputation systems, trust mechanisms, and governance models for decentralized environments. | Active |
+| [Whitepaper](whitepaper/README.md) | Collaborates on technical whitepapers and reports related to AI technologies and the Eliza project. | Active |
 
 ## Empty/Pending Workgroups
 
 The following workgroups have been created but don't have content yet:
 
-- [Evolve](workgroups/evolve/README.md)
-- [Partner Portal](workgroups/partner-portal/README.md)
+- [Evolve](evolve/README.md)
+- [Partner Portal](partner-portal/README.md)
 
 ## Getting Involved
 


### PR DESCRIPTION
This PR fixes incorrect workgroup links in `README.md` by removing the workgroups directory from all paths.